### PR TITLE
fix: launching puppeteer not using jest-puppeteer causing an error on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "posttest": "eslint .",
-    "test": "jest toMatchScreenshotJest.test.js && jest toMatchScreenshotChai.test.js",
+    "test": "jest",
     "release": "wnpm-release --no-shrinkwrap"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "posttest": "eslint .",
-    "test": "jest",
+    "test": "jest --maxWorkers=3",
     "release": "wnpm-release --no-shrinkwrap"
   },
   "jest": {

--- a/tests/__fixtures__/test.mocha.js
+++ b/tests/__fixtures__/test.mocha.js
@@ -1,20 +1,15 @@
-const [, , , chaiToMatchScreenshot] = process.argv;
+const [, , , chaiToMatchScreenshot, browserWSEndpoint] = process.argv;
 const {Assertion, expect} = require('chai');
 
 const toMatchScreenshot = require(chaiToMatchScreenshot);
 
 Assertion.addMethod('toMatchScreenshot', toMatchScreenshot);
-
 it(`should work with chai`, async function() { // eslint-disable-line
   this.timeout(30000);
   const puppeteer = require('puppeteer');
 
-  const browser = await puppeteer.launch({
-    args: [
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
-      '--disable-dev-shm-usage', // https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#tips
-    ],
+  const browser = await puppeteer.connect({
+    browserWSEndpoint,
   });
 
   const page = await browser.newPage();
@@ -23,5 +18,5 @@ it(`should work with chai`, async function() { // eslint-disable-line
   await expect(screenshot).toMatchScreenshot({
     key: 'should work with chai',
   });
-  await browser.close();
+  await browser.disconnect();
 });

--- a/tests/toMatchScreenshotChai.test.js
+++ b/tests/toMatchScreenshotChai.test.js
@@ -4,12 +4,13 @@ describe('EYES', () => {
   jest.setTimeout(30000);
   describe('Log', () => {
     test('should log after eyes success', async () => {
+      const browserWSEndpoint = global.browser.wsEndpoint();
       const res = await execa('node', [
         require.resolve('mocha/bin/mocha'),
         require.resolve('./__fixtures__/test.mocha'),
         require.resolve('../lib/chai'),
+        browserWSEndpoint,
       ]);
-
       expect(res.stdout).toContain(
         'eyes comparison succeed for test "should work with chai v1.0.0"',
       );


### PR DESCRIPTION
fixes #3 